### PR TITLE
fix the "Can't pickle error"

### DIFF
--- a/simhash/__init__.py
+++ b/simhash/__init__.py
@@ -16,6 +16,10 @@ else:
     range = xrange
 
 
+def _hashfunc(x):
+    return int(hashlib.md5(x).hexdigest(), 16)
+
+
 class Simhash(object):
 
     def __init__(self, value, f=64, reg=r'[\w\u4e00-\u9fcc]+', hashfunc=None):
@@ -36,9 +40,6 @@ class Simhash(object):
         self.value = None
 
         if hashfunc is None:
-            def _hashfunc(x):
-                return int(hashlib.md5(x).hexdigest(), 16)
-
             self.hashfunc = _hashfunc
         else:
             self.hashfunc = hashfunc


### PR DESCRIPTION
Hi,

Currently simhash objects cannot be pickled. This is only because the default hash function is defined inside the Simhash class. Moving the definition outside the class fixes that problem.