### PR TITLE
added function to get doc clusters from index and hashed docs

### DIFF
--- a/simhash/__init__.py
+++ b/simhash/__init__.py
@@ -8,7 +8,6 @@ import numbers
 import re
 import sys
 from itertools import groupby
-from typing import Type
 
 import numpy as np
 
@@ -264,7 +263,7 @@ class SimhashIndex(object):
         return len(self.bucket)
 
 
-def determine_clusters(index: Type[SimhashIndex], hashed_docs: list) -> dict:
+def determine_clusters(index, hashed_docs):
     """
     Builds clusters of similar documents
 

--- a/simhash/__init__.py
+++ b/simhash/__init__.py
@@ -8,6 +8,7 @@ import numbers
 import re
 import sys
 from itertools import groupby
+from typing import Type
 
 import numpy as np
 
@@ -261,3 +262,22 @@ class SimhashIndex(object):
 
     def bucket_size(self):
         return len(self.bucket)
+
+
+def determine_clusters(index: Type[SimhashIndex], hashed_docs: list) -> dict:
+    """
+    Builds clusters of similar documents
+
+    :param index: SimhashIndex object
+    :param hashed_docs: list of tuples of (doc_id, Simhash object)
+    """
+    clusters = {}
+    cluster = 0
+    seen = set()
+    for doc in hashed_docs:
+        if doc[0] not in seen:
+            clusters[cluster] = set(index.get_near_dups(doc[1]))
+            seen.update(clusters[cluster])
+            cluster += 1
+    return clusters
+

--- a/tests/test_simhash.py
+++ b/tests/test_simhash.py
@@ -4,7 +4,7 @@ from unittest import main, TestCase
 
 from sklearn.feature_extraction.text import TfidfVectorizer
 
-from simhash import Simhash, SimhashIndex
+from simhash import Simhash, SimhashIndex, determine_clusters
 
 
 class TestSimhash(TestCase):
@@ -145,6 +145,34 @@ class TestSimhashIndex(TestCase):
         self.index.add('1', Simhash(self.data[1]))
         dups = self.index.get_near_dups(s1)
         self.assertEqual(3, len(dups))
+
+
+class TestDetermineClusters(TestCase):
+    data = {
+        1: 'How are you? I Am fine. blar blar blar blar blar Thanks.',
+        2: 'How are you? I Am fine. blar blar blar blar blar Thanks.',
+        3: 'This is simhash test.',
+        4: 'How are you i am fine. blar blar blar blar blar thank1',
+    }
+
+    def setUp(self):
+        self.objs = [(str(k), Simhash(v)) for k, v in self.data.items()]
+
+    def test_exact_match_same_cluster(self):
+        expected_cluster = {'1', '2'}
+        index = SimhashIndex(self.objs, k=1)
+        clusters = determine_clusters(index, self.objs)
+        self.assertEqual((clusters[0] - expected_cluster), set())
+        self.assertEqual((expected_cluster - clusters[0]), set())
+        self.assertEqual(len(clusters), 3)
+
+    def test_approximate_match_same_cluster(self):
+        expected_cluster = {'1', '2', '4'}
+        index = SimhashIndex(self.objs, k=4)
+        clusters = determine_clusters(index, self.objs)
+        self.assertEqual((clusters[0] - expected_cluster), set())
+        self.assertEqual((expected_cluster - clusters[0]), set())
+        self.assertEqual(len(clusters), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added a function to identify clusters of similar documents.  This will produce a dictionary of sets where the sets contain the documents that are matched by get_near_dups().  This function is useful when you want to group documents by similarity.  